### PR TITLE
upgrade-threshold-crypto-libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,12 +31,12 @@ env_logger = "0.9.0"
 hex_fmt = "0.3.0"
 init_with = "1.1.0"
 log = "0.4.17"
-rand = "0.7"
+rand = "0.8.5"
 rand_derive = "0.5.0"
 reed-solomon-erasure = "5.0.3"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 thiserror = "1.0.31"
-threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
+threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 
 [dev-dependencies]
@@ -44,10 +44,10 @@ colored = "2.0.0"
 crossbeam = "0.8.1"
 crossbeam-channel = "0.5.5"
 docopt = "1.1.1"
-hbbft_testing = { path = "hbbft_testing", features = ["use-insecure-test-only-mock-crypto"] }
+hbbft_testing = { path = "hbbft_testing" }
 itertools = "0.10.3"
 number_prefix = "0.4.0"
-proptest = "0.10.1"
+proptest = "1.0.0"
 
 [[example]]
 name = "consensus-node"
@@ -62,5 +62,4 @@ name = "simulation"
 overflow-checks = true
 
 [features]
-use-insecure-test-only-mock-crypto = ["threshold_crypto/use-insecure-test-only-mock-crypto"]
 simd-accel = ["reed-solomon-erasure/simd-accel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rand_derive = "0.5.0"
 reed-solomon-erasure = "5.0.3"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 thiserror = "1.0.31"
-threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 
 [dev-dependencies]

--- a/ci.sh
+++ b/ci.sh
@@ -16,8 +16,7 @@ cargo clippy --all-targets # -- --deny clippy::all
 cargo clippy --all-features --all-targets # -- --deny clippy::all
 cargo fmt -- --check
 
-# We only test with mocktography, to ensure tests aren't unreasonably long.
-cargo test --features=use-insecure-test-only-mock-crypto --release
+cargo test --release
 cargo doc
 cargo deadlinks --dir target/doc/hbbft/
 cargo audit
@@ -26,5 +25,5 @@ cd hbbft_testing
 # allow warnings for now
 cargo clippy --all-targets # -- --deny clippy::all
 cargo fmt -- --check
-cargo test --features=use-insecure-test-only-mock-crypto --release
+cargo test --release
 cd ..

--- a/examples/simulation.rs
+++ b/examples/simulation.rs
@@ -206,10 +206,9 @@ where
 
     /// Returns the time when the next message can be handled.
     fn next_event_time(&self) -> Option<Duration> {
-        match self.in_queue.front() {
-            None => None,
-            Some(ts_msg) => Some(cmp::max(ts_msg.time, self.time)),
-        }
+        self.in_queue
+            .front()
+            .map(|ts_msg| cmp::max(ts_msg.time, self.time))
     }
 
     /// Returns the number of messages this node has handled so far.
@@ -330,7 +329,7 @@ struct EpochInfo {
     nodes: BTreeMap<NodeId, (Duration, Batch<Transaction, NodeId>)>,
 }
 
-type QHB = SenderQueue<QueueingHoneyBadger<Transaction, NodeId, Vec<Transaction>>>;
+type Qhb = SenderQueue<QueueingHoneyBadger<Transaction, NodeId, Vec<Transaction>>>;
 
 impl EpochInfo {
     /// Adds a batch to this epoch. Prints information if the epoch is complete.
@@ -339,7 +338,7 @@ impl EpochInfo {
         id: NodeId,
         time: Duration,
         batch: &Batch<Transaction, NodeId>,
-        network: &TestNetwork<QHB>,
+        network: &TestNetwork<Qhb>,
     ) {
         if self.nodes.contains_key(&id) {
             return;
@@ -373,7 +372,7 @@ impl EpochInfo {
 }
 
 /// Proposes `num_txs` values and expects nodes to output and order them.
-fn simulate_honey_badger<R: Rng>(mut network: TestNetwork<QHB>, rng: &mut R) {
+fn simulate_honey_badger<R: Rng>(mut network: TestNetwork<Qhb>, rng: &mut R) {
     // Handle messages until all nodes have output all transactions.
     println!(
         "{}",
@@ -399,6 +398,7 @@ fn parse_args() -> Result<Args, docopt::Error> {
         .deserialize()
 }
 
+#[allow(clippy::needless_collect)]
 fn main() {
     env_logger::init();
     let mut rng = OsRng;

--- a/hbbft_testing/Cargo.toml
+++ b/hbbft_testing/Cargo.toml
@@ -28,4 +28,4 @@ proptest = "1.0.0"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
 thiserror = "1.0.31"
-threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }
+threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }

--- a/hbbft_testing/Cargo.toml
+++ b/hbbft_testing/Cargo.toml
@@ -24,11 +24,8 @@ travis-ci = { repository = "poanetwork/hbbft" }
 [dependencies]
 hbbft = { path = ".." }
 integer-sqrt = "0.1.2"
-proptest = "0.10.1"
-rand = "0.7"
-rand_xorshift = "0.2.0"
+proptest = "1.0.0"
+rand = "0.8.5"
+rand_xorshift = "0.3.0"
 thiserror = "1.0.31"
-threshold_crypto = { git = "https://github.com/fedimint/threshold_crypto" }
-
-[features]
-use-insecure-test-only-mock-crypto = ["hbbft/use-insecure-test-only-mock-crypto"]
+threshold_crypto = { git = "https://github.com/elsirion/threshold_crypto", branch = "2022-08-upgrade-pairing" }

--- a/hbbft_testing/src/adversary.rs
+++ b/hbbft_testing/src/adversary.rs
@@ -376,7 +376,7 @@ where
     D::Output: Clone,
     A: Adversary<D>,
 {
-    net.sort_messages_by(|a, b| a.to().cmp(&b.to()))
+    net.sort_messages_by(|a, b| a.to().cmp(b.to()))
 }
 
 /// Utility function to swap the topmost message with a random message in the queue

--- a/hbbft_testing/src/adversary.rs
+++ b/hbbft_testing/src/adversary.rs
@@ -391,7 +391,7 @@ where
 {
     let l = net.get_messages().len();
     if l > 0 {
-        net.swap_messages(0, rng.gen_range(0, l));
+        net.swap_messages(0, rng.gen_range(0..l));
     }
 }
 
@@ -410,7 +410,7 @@ where
         // Pick a node id at random
         return Some(
             net.nodes_mut()
-                .nth(rng.gen_range(0, l))
+                .nth(rng.gen_range(0..l))
                 .expect("nodes list changed since last call")
                 .id(),
         );

--- a/hbbft_testing/src/err.rs
+++ b/hbbft_testing/src/err.rs
@@ -71,26 +71,34 @@ where
             CrankError::HandleInput(err) => {
                 write!(f, "The algorithm could not process input: {:?}", err)
             }
-            CrankError::HandleInputAll(err) => write!(
-                f,
-                "The algorithm could not process input to all nodes: {:?}",
-                err
-            ),
-            CrankError::HandleMessage { msg, err } => write!(
-                f,
-                "The algorithm could not process network message {:?}. Error: {:?}",
-                msg, err
-            ),
-            CrankError::NodeDisappearedInCrank(id) => write!(
-                f,
-                "Node {:?} disappeared or never existed, while it was cranked.",
-                id
-            ),
-            CrankError::NodeDisappearedInDispatch(id) => write!(
-                f,
-                "Node {:?} disappeared or never existed, while it still had incoming messages.",
-                id
-            ),
+            CrankError::HandleInputAll(err) => {
+                write!(
+                    f,
+                    "The algorithm could not process input to all nodes: {:?}",
+                    err
+                )
+            }
+            CrankError::HandleMessage { msg, err } => {
+                write!(
+                    f,
+                    "The algorithm could not process network message {:?}. Error: {:?}",
+                    msg, err
+                )
+            }
+            CrankError::NodeDisappearedInCrank(id) => {
+                write!(
+                    f,
+                    "Node {:?} disappeared or never existed, while it was cranked.",
+                    id
+                )
+            }
+            CrankError::NodeDisappearedInDispatch(id) => {
+                write!(
+                    f,
+                    "Node {:?} disappeared or never existed, while it still had incoming messages.",
+                    id
+                )
+            }
             CrankError::CrankLimitExceeded(max) => {
                 write!(f, "Maximum number of cranks exceeded: {}", max)
             }
@@ -104,16 +112,16 @@ where
                 reported_by,
                 faulty_id,
                 fault_kind,
-            } => write!(
-                f,
-                "Correct node {:?} reported node {:?} as faulty: {:?}.",
-                reported_by, faulty_id, fault_kind
-            ),
-            CrankError::InitialKeyGeneration(err) => write!(
-                f,
-                "An error occurred while generating initial keys for threshold cryptography: {:?}.",
-                err
-            ),
+            } => {
+                write!(
+                    f,
+                    "Correct node {:?} reported node {:?} as faulty: {:?}.",
+                    reported_by, faulty_id, fault_kind
+                )
+            }
+            CrankError::InitialKeyGeneration(err) => {
+                write!(f, "An error occurred while generating initial keys for threshold cryptography: {:?}.", err)
+            }
         }
     }
 }

--- a/hbbft_testing/src/lib.rs
+++ b/hbbft_testing/src/lib.rs
@@ -535,10 +535,10 @@ where
 
         // If the trace setting is not overriden, we use the setting from the environment.
         let trace = self.trace.unwrap_or_else(|| {
-            match env::var("HBBFT_TEST_TRACE").as_ref().map(String::as_str) {
-                Ok("true") | Ok("1") => true,
-                _ => false,
-            }
+            matches!(
+                env::var("HBBFT_TEST_TRACE").as_ref().map(String::as_str),
+                Ok("true") | Ok("1")
+            )
         });
 
         if trace {
@@ -670,7 +670,7 @@ where
     /// Returns `None` if the node ID is not part of the network.
     #[inline]
     #[allow(clippy::needless_pass_by_value)]
-    pub fn get<'a>(&'a self, id: D::NodeId) -> Option<&'a Node<D>> {
+    pub fn get(&self, id: D::NodeId) -> Option<&Node<D>> {
         self.nodes.get(&id)
     }
 
@@ -679,7 +679,7 @@ where
     /// Returns `None` if the node ID is not part of the network.
     #[inline]
     #[allow(clippy::needless_pass_by_value)]
-    pub fn get_mut<'a>(&'a mut self, id: D::NodeId) -> Option<&'a mut Node<D>> {
+    pub fn get_mut(&mut self, id: D::NodeId) -> Option<&mut Node<D>> {
         self.nodes.get_mut(&id)
     }
 

--- a/hbbft_testing/src/proptest.rs
+++ b/hbbft_testing/src/proptest.rs
@@ -124,9 +124,9 @@ impl NetworkDimensionTree {
         // A common mistake, add an extra assert for a more helpful error message.
         assert!(min_size > 0, "minimum network size is 1");
 
-        let total = rng.gen_range(min_size, max_size + 1);
+        let total = rng.gen_range(min_size..max_size + 1);
         let max_faulty = (total - 1) / 3;
-        let faulty = rng.gen_range(0, max_faulty + 1);
+        let faulty = rng.gen_range(0..max_faulty + 1);
 
         let high = NetworkDimension::new(total, faulty);
 

--- a/hbbft_testing/src/util.rs
+++ b/hbbft_testing/src/util.rs
@@ -23,5 +23,5 @@ macro_rules! try_some {
 pub fn randomly<R: Rng>(probability: f32, rng: &mut R) -> bool {
     assert!(probability <= 1.0);
     assert!(probability >= 0.0);
-    rng.gen_range(0.0, 1.0) <= probability
+    rng.gen_range(0.0..1.0) <= probability
 }

--- a/src/binary_agreement/binary_agreement.rs
+++ b/src/binary_agreement/binary_agreement.rs
@@ -294,7 +294,7 @@ impl<N: NodeIdT, S: SessionIdT> BinaryAgreement<N, S> {
         sender_id: &N,
         msg: &sbv_broadcast::Message,
     ) -> Result<Step<N>> {
-        let sbvb_step = self.sbv_broadcast.handle_message(sender_id, &msg)?;
+        let sbvb_step = self.sbv_broadcast.handle_message(sender_id, msg)?;
         self.handle_sbvb_step(sbvb_step)
     }
 
@@ -375,7 +375,7 @@ impl<N: NodeIdT, S: SessionIdT> BinaryAgreement<N, S> {
         self.conf_values = Some(values);
 
         if !self.netinfo.is_validator() {
-            return Ok(self.try_finish_conf_round()?);
+            return self.try_finish_conf_round();
         }
 
         self.send(MessageContent::Conf(values))

--- a/src/binary_agreement/mod.rs
+++ b/src/binary_agreement/mod.rs
@@ -106,7 +106,7 @@ impl From<bincode::Error> for Error {
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// A faulty Binary Agreement message received from a peer.
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum FaultKind {
     /// `BinaryAgreement` received a duplicate `BVal` message.
     #[error("`BinaryAgreement` received a duplicate `BVal` message.")]
@@ -131,7 +131,7 @@ pub enum FaultKind {
 pub type Step<N> = crate::Step<Message, bool, N, FaultKind>;
 
 /// The content of a message belonging to a particular `BinaryAgreement` epoch.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum MessageContent {
     /// Synchronized Binary Value Broadcast message.
     SbvBroadcast(sbv_broadcast::Message),
@@ -153,6 +153,7 @@ impl MessageContent {
     }
 
     /// Returns `true` if this message can be ignored if its epoch has already passed.
+    #[allow(clippy::match_like_matches_macro)]
     pub fn can_expire(&self) -> bool {
         match *self {
             MessageContent::Term(_) => false,
@@ -162,7 +163,7 @@ impl MessageContent {
 }
 
 /// Messages sent during the Binary Agreement stage.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Rand)]
 pub struct Message {
     /// The `BinaryAgreement` epoch this message belongs to.
     pub epoch: u64,

--- a/src/binary_agreement/sbv_broadcast.rs
+++ b/src/binary_agreement/sbv_broadcast.rs
@@ -143,7 +143,7 @@ impl<N: NodeIdT> SbvBroadcast<N> {
         }
         let step: Step<_> = Target::all().message(msg.clone()).into();
         let our_id = &self.netinfo.our_id().clone();
-        Ok(step.join(self.handle_message(our_id, &msg)?))
+        Ok(step.join(self.handle_message(our_id, msg)?))
     }
 
     /// Handles an `Aux` message.

--- a/src/broadcast/broadcast.rs
+++ b/src/broadcast/broadcast.rs
@@ -251,7 +251,7 @@ impl<N: NodeIdT> Broadcast<N> {
         };
 
         // If the proof is invalid, log the faulty node behavior and ignore.
-        if !self.validate_proof(&p, &self.our_id()) {
+        if !self.validate_proof(&p, self.our_id()) {
             return Ok(Fault::new(sender_id.clone(), FaultKind::InvalidProof).into());
         }
 
@@ -347,11 +347,11 @@ impl<N: NodeIdT> Broadcast<N> {
         self.echos
             .insert(sender_id.clone(), EchoContent::Hash(*hash));
 
-        if self.ready_sent || self.count_echos(&hash) < self.val_set.num_correct() {
-            return self.compute_output(&hash);
+        if self.ready_sent || self.count_echos(hash) < self.val_set.num_correct() {
+            return self.compute_output(hash);
         }
         // Upon receiving `N - f` `Echo`s with this root hash, multicast `Ready`.
-        self.send_ready(&hash)
+        self.send_ready(hash)
     }
 
     /// Handles a received `CanDecode` message.
@@ -486,7 +486,7 @@ impl<N: NodeIdT> Broadcast<N> {
 
     /// Sends a `CanDecode` message and handles it. Does nothing if we are only an observer.
     fn send_can_decode(&mut self, hash: &Digest) -> Result<Step<N>> {
-        self.can_decode_sent.insert(hash.clone());
+        self.can_decode_sent.insert(*hash);
         if !self.val_set.contains(&self.our_id) {
             return Ok(Step::default());
         }

--- a/src/broadcast/error.rs
+++ b/src/broadcast/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 /// A broadcast error.
-#[derive(Clone, PartialEq, Debug, Error)]
+#[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum Error {
     /// Due to a limitation in `reed_solomon_erasure`, only up to 256 nodes are supported.
     #[error("Number of participants must be between 1 and 256")]
@@ -24,7 +24,7 @@ pub enum Error {
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// Represents each reason why a broadcast message could be faulty.
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum FaultKind {
     /// `Broadcast` received a `Value` from a node other than the proposer.
     #[error("`Broadcast` received a `Value` from a node other than the proposer.")]

--- a/src/broadcast/merkle.rs
+++ b/src/broadcast/merkle.rs
@@ -69,7 +69,7 @@ impl<T: AsRef<[u8]> + Clone> MerkleTree<T> {
 }
 
 /// A proof that a value is at a particular index in the Merkle tree specified by its root hash.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Proof<T> {
     value: T,
     index: usize,

--- a/src/broadcast/message.rs
+++ b/src/broadcast/message.rs
@@ -9,7 +9,7 @@ use super::merkle::{Digest, MerkleTree, Proof};
 
 /// The three kinds of message sent during the reliable broadcast stage of the
 /// consensus algorithm.
-#[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub enum Message {
     /// A share of the value, sent from the sender to another validator.
     Value(Proof<Vec<u8>>),

--- a/src/dynamic_honey_badger/dynamic_honey_badger.rs
+++ b/src/dynamic_honey_badger/dynamic_honey_badger.rs
@@ -268,7 +268,7 @@ where
 
     /// Returns the information about the node IDs in the network, and the cryptographic keys.
     pub fn netinfo(&self) -> &Arc<NetworkInfo<N>> {
-        &self.honey_badger.netinfo()
+        self.honey_badger.netinfo()
     }
 
     /// Returns a reference to the internal managed `HoneyBadger` instance.
@@ -495,7 +495,7 @@ where
     ) -> Result<Step<C, N>> {
         let outcome = if let Some(kgs) = self.key_gen_state.as_mut() {
             kgs.key_gen
-                .handle_part(&sender_id, part, rng)
+                .handle_part(sender_id, part, rng)
                 .map_err(Error::SyncKeyGen)?
         } else {
             // No key generation ongoing.
@@ -575,7 +575,7 @@ where
         kg_msg: &KeyGenMessage,
     ) -> Result<bool> {
         let ser = bincode::serialize(kg_msg).map_err(|err| Error::SerializeKeyGen(*err))?;
-        let verify = |opt_pk: Option<&PublicKey>| opt_pk.map_or(false, |pk| pk.verify(&sig, &ser));
+        let verify = |opt_pk: Option<&PublicKey>| opt_pk.map_or(false, |pk| pk.verify(sig, &ser));
         let kgs = self.key_gen_state.as_ref();
         let current_key = self.pub_keys.get(node_id);
         let candidate_key = kgs.and_then(|kgs| kgs.public_keys().get(node_id));

--- a/src/dynamic_honey_badger/error.rs
+++ b/src/dynamic_honey_badger/error.rs
@@ -33,7 +33,7 @@ pub enum Error {
 /// The result of `DynamicHoneyBadger` handling an input or message.
 pub type Result<T> = ::std::result::Result<T, Error>;
 /// Represents each way an an incoming message can be considered faulty.
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum FaultKind {
     /// `DynamicHoneyBadger` received a key generation message with an invalid signature.
     #[error("`DynamicHoneyBadger` received a key generation message with an invalid signature.")]

--- a/src/fault_log.rs
+++ b/src/fault_log.rs
@@ -9,7 +9,7 @@ use std::error::Error;
 /// A structure representing the context of a faulty node. This structure
 /// describes which node is faulty (`node_id`) and which faulty behavior
 /// that the node exhibited (`kind`).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Fault<N, F: Error> {
     /// The faulty node's ID.
     pub node_id: N,
@@ -41,6 +41,7 @@ where
 
 /// Creates a new `FaultLog` where `self` is the first element in the log
 /// vector.
+#[allow(clippy::from_over_into)]
 impl<N, F> Into<FaultLog<N, F>> for Fault<N, F>
 where
     F: Error,
@@ -51,7 +52,7 @@ where
 }
 
 /// A structure used to contain reports of faulty node behavior.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct FaultLog<N, F: Error>(pub Vec<Fault<N, F>>);
 
 impl<N, F> FaultLog<N, F>

--- a/src/honey_badger/epoch_state.rs
+++ b/src/honey_badger/epoch_state.rs
@@ -2,7 +2,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{self, Display};
 use std::marker::PhantomData;
-use std::mem::replace;
+
 use std::result;
 use std::sync::Arc;
 
@@ -149,7 +149,7 @@ impl<N> SubsetHandler<N> {
             Done => {
                 contributions = match self {
                     Incremental => vec![],
-                    AllAtEnd(cs) => replace(cs, vec![]),
+                    AllAtEnd(cs) => std::mem::take(cs),
                 };
                 is_done = true;
             }
@@ -253,7 +253,7 @@ where
                 self.process_subset(cs_step)
             }
             MessageContent::DecryptionShare { proposer_id, share } => {
-                if let Some(ref ids) = self.subset.accepted_ids() {
+                if let Some(ids) = self.subset.accepted_ids() {
                     if !ids.contains(&proposer_id) {
                         let fault_kind = FaultKind::UnexpectedDecryptionShare;
                         return Ok(Fault::new(sender_id.clone(), fault_kind).into());

--- a/src/honey_badger/error.rs
+++ b/src/honey_badger/error.rs
@@ -32,7 +32,7 @@ pub enum Error {
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// Faults detectable from receiving honey badger messages
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum FaultKind {
     /// `HoneyBadger` received a decryption share for an unaccepted proposer.
     #[error("`HoneyBadger` received a decryption share for an unaccepted proposer.")]

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -51,7 +51,7 @@ impl<N: Ord> Target<N> {
 }
 
 /// Message with a designated target.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TargetedMessage<M, N> {
     /// The node or nodes that this message must be delivered to.
     pub target: Target<N>,

--- a/src/network_info.rs
+++ b/src/network_info.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use crate::crypto::{self, PublicKeySet, PublicKeyShare, SecretKeyShare};
-use rand;
 
 use crate::{util, NodeIdT};
 

--- a/src/sender_queue/mod.rs
+++ b/src/sender_queue/mod.rs
@@ -243,6 +243,7 @@ where
     }
 
     /// Processes an announcement of a new epoch update received from a remote node.
+    #[allow(clippy::needless_collect)]
     fn process_new_epoch(&mut self, sender_id: &D::NodeId, epoch: D::Epoch) -> CpStep<Self> {
         let queue = match self.outgoing_queue.get_mut(sender_id) {
             None => return CpStep::<Self>::default(),
@@ -306,7 +307,7 @@ where
                     .difference(&next_participants)
                 {
                     // Begin the participant removal process.
-                    self.remove_participant_after(&id, &batch.output_epoch());
+                    self.remove_participant_after(id, &batch.output_epoch());
                 }
                 if self.participants_after_change.contains(&self.our_id)
                     && !next_participants.contains(&self.our_id)
@@ -348,7 +349,7 @@ where
     /// superseded by a new set of participants of which it is not a member. Returns `true` if the
     /// participant has been removed and `false` otherwise.
     fn remove_participant_after(&mut self, id: &D::NodeId, last_epoch: &D::Epoch) -> bool {
-        self.last_epochs.insert(id.clone(), last_epoch.clone());
+        self.last_epochs.insert(id.clone(), *last_epoch);
         self.remove_participant_if_old(id)
     }
 
@@ -379,10 +380,10 @@ where
                     return false;
                 }
             }
-            self.peer_epochs.remove(&id);
-            self.outgoing_queue.remove(&id);
+            self.peer_epochs.remove(id);
+            self.outgoing_queue.remove(id);
         }
-        self.last_epochs.remove(&id);
+        self.last_epochs.remove(id);
         true
     }
 

--- a/src/subset/error.rs
+++ b/src/subset/error.rs
@@ -6,7 +6,7 @@ use crate::binary_agreement;
 use crate::broadcast;
 
 /// A subset error.
-#[derive(Clone, PartialEq, Debug, Error)]
+#[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum Error {
     /// Error creating `BinaryAgreement`.
     #[error("Error creating BinaryAgreement: {0}")]
@@ -29,7 +29,7 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 /// Faults that can be detected in Subset.
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum FaultKind {
     /// `Subset` received a faulty Broadcast message.
     #[error("`Subset` received a faulty Broadcast message.")]

--- a/src/sync_key_gen.rs
+++ b/src/sync_key_gen.rs
@@ -187,11 +187,11 @@ use crate::crypto::{
     error::Error as CryptoError,
     poly::{BivarCommitment, BivarPoly, Poly},
     serde_impl::FieldWrap,
-    Scalar, G1Affine, PublicKeySet, SecretKeyShare,
+    G1Affine, PublicKeySet, Scalar, SecretKeyShare,
 };
-use std::ops::Mul;
 use crate::NodeIdT;
 use std::ops::AddAssign;
+use std::ops::Mul;
 
 /// A cryptographic key that allows decrypting messages that were encrypted to the key's owner.
 pub trait SecretKey {
@@ -415,7 +415,7 @@ impl<N: NodeIdT, PK: PublicKey> SyncKeyGen<N, PK> {
         let commit = our_part.commitment();
         let encrypt = |(i, pk): (usize, &PK)| {
             let row = bincode::serialize(&our_part.row(i + 1))?;
-            Ok(pk.encrypt(&row, rng).map_err(Error::encrypt)?)
+            pk.encrypt(&row, rng).map_err(Error::encrypt)
         };
         let rows = key_gen
             .pub_keys

--- a/src/threshold_decrypt.rs
+++ b/src/threshold_decrypt.rs
@@ -47,7 +47,7 @@ pub enum Error {
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// A threshold decryption message fault
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum FaultKind {
     /// `ThresholdDecrypt` received multiple shares from the same sender.
     #[error("`ThresholdDecrypt` received multiple shares from the same sender.")]
@@ -61,7 +61,7 @@ pub enum FaultKind {
 pub type FaultLog<N> = fault_log::FaultLog<N, FaultKind>;
 
 /// A Threshold Decryption message.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Rand)]
 pub struct Message(pub DecryptionShare);
 
 /// A Threshold Decrypt algorithm instance. If every node inputs the same data, encrypted to the

--- a/src/threshold_sign.rs
+++ b/src/threshold_sign.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::{fmt, result};
 
-use crate::crypto::{self, hash_g2, Signature, SignatureShare, G2Projective};
+use crate::crypto::{self, hash_g2, G2Projective, Signature, SignatureShare};
 use log::debug;
 use rand::Rng;
 use rand_derive::Rand;
@@ -53,7 +53,7 @@ pub enum Error {
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// A threshold sign message fault
-#[derive(Clone, Debug, Error, PartialEq)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum FaultKind {
     /// `ThresholdSign` (`Coin`) received a signature share from an unverified sender.
     #[error("`ThresholdSign` (`Coin`) received a signature share from an unverified sender.")]
@@ -67,7 +67,7 @@ pub enum FaultKind {
 }
 
 /// A threshold signing message, containing a signature share.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Rand)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Rand)]
 pub struct Message(pub SignatureShare);
 
 /// A threshold signing algorithm instance. On input, broadcasts our threshold signature share. Upon
@@ -218,7 +218,7 @@ impl<N: NodeIdT> ThresholdSign<N> {
         };
         match self.netinfo.public_key_share(id) {
             None => false, // Unknown sender.
-            Some(pk_i) => pk_i.verify_g2(&share, *hash),
+            Some(pk_i) => pk_i.verify_g2(share, *hash),
         }
     }
 

--- a/src/threshold_sign.rs
+++ b/src/threshold_sign.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::{fmt, result};
 
-use crate::crypto::{self, hash_g2, Signature, SignatureShare, G2};
+use crate::crypto::{self, hash_g2, Signature, SignatureShare, G2Projective};
 use log::debug;
 use rand::Rng;
 use rand_derive::Rand;
@@ -77,7 +77,7 @@ pub struct Message(pub SignatureShare);
 pub struct ThresholdSign<N> {
     netinfo: Arc<NetworkInfo<N>>,
     /// The hash of the document to be signed.
-    doc_hash: Option<G2>,
+    doc_hash: Option<G2Projective>,
     /// All received threshold signature shares, together with the node index.
     received_shares: BTreeMap<N, (usize, SignatureShare)>,
     /// Whether we already sent our shares.
@@ -244,7 +244,7 @@ impl<N: NodeIdT> ThresholdSign<N> {
         }
     }
 
-    fn combine_and_verify_sig(&self, hash: G2) -> Result<Signature> {
+    fn combine_and_verify_sig(&self, hash: G2Projective) -> Result<Signature> {
         // Pass the indices of sender nodes to `combine_signatures`.
         let shares_itr = self
             .received_shares

--- a/tests/binary_agreement_mitm.rs
+++ b/tests/binary_agreement_mitm.rs
@@ -233,7 +233,7 @@ struct AbaCommonCoinAdversary {
 }
 
 const NODES_PER_GROUP: usize = 2;
-const NUM_NODES: usize = (NODES_PER_GROUP * 3 + 1);
+const NUM_NODES: usize = NODES_PER_GROUP * 3 + 1;
 
 impl AbaCommonCoinAdversary {
     fn new<R: Rng>(

--- a/tests/binary_agreement_mitm.rs
+++ b/tests/binary_agreement_mitm.rs
@@ -385,7 +385,7 @@ impl Adversary<Algo> for AbaCommonCoinAdversary {
         });
         let mut redo_crank = false;
         if let Some(msg) = net.get_messages().front() {
-            if msg.payload().epoch == self.epoch && self.stage_matches_msg(&msg) {
+            if msg.payload().epoch == self.epoch && self.stage_matches_msg(msg) {
                 self.stage_progress += 1;
                 self.on_stage_progress_update();
             }

--- a/tests/broadcast.rs
+++ b/tests/broadcast.rs
@@ -153,8 +153,8 @@ where
 {
     let mut rng: TestRng = TestRng::from_seed(seed);
     let sizes = (1..6)
-        .chain(once(rng.gen_range(6, 20)))
-        .chain(once(rng.gen_range(30, 50)));
+        .chain(once(rng.gen_range(6..20)))
+        .chain(once(rng.gen_range(30..50)));
     for size in sizes {
         // cloning since it gets moved into a closure
         let num_faulty_nodes = util::max_faulty(size);
@@ -164,7 +164,7 @@ where
             num_faulty_nodes
         );
 
-        let proposer_id = rng.gen_range(0, size) as NodeId;
+        let proposer_id = rng.gen_range(0..size) as NodeId;
 
         let (net, _) = NetBuilder::new(0..size as u16)
             .num_faulty(num_faulty_nodes as usize)
@@ -237,7 +237,7 @@ fn do_test_8_broadcast_equal_leaves_silent(seed: TestRngSeed) {
     let size = 8;
 
     let num_faulty = 0;
-    let proposer_id = rng.gen_range(0, size);
+    let proposer_id = rng.gen_range(0..size);
     let (net, _) = NetBuilder::new(0..size as u16)
         .num_faulty(num_faulty as usize)
         .message_limit(10_000 * size as usize)

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -499,9 +499,9 @@ where
             "the network is already captured by the faulty nodes"
         );
 
-        let new_n = rng.gen_range(2, n); // new_n is between 2 and n-1
+        let new_n = rng.gen_range(2..n); // new_n is between 2 and n-1
         let min_new_f = f.saturating_sub(n - new_n);
-        let new_f = rng.gen_range(min_new_f, f.min(util::max_faulty(new_n)) + 1);
+        let new_f = rng.gen_range(min_new_f..f.min(util::max_faulty(new_n)) + 1);
 
         let remove_from_faulty = f - new_f;
         let remove_from_correct = n - new_n - remove_from_faulty;

--- a/tests/dynamic_honey_badger.rs
+++ b/tests/dynamic_honey_badger.rs
@@ -13,7 +13,7 @@ use hbbft_testing::{NetBuilder, NewNodeInfo, Node, VirtualNet};
 use proptest::{prelude::ProptestConfig, prop_compose, proptest};
 use rand::{seq::SliceRandom, SeedableRng};
 
-type DHB = SenderQueue<DynamicHoneyBadger<Vec<usize>, usize>>;
+type Dhb = SenderQueue<DynamicHoneyBadger<Vec<usize>, usize>>;
 
 /// Chooses a node's contribution for an epoch.
 ///
@@ -409,7 +409,7 @@ fn do_drop_and_re_add(cfg: TestConfig) {
         .correct_nodes()
         .filter(|node| !nodes_for_remove.contains(node.id()))
         .map(|node| {
-            state.net.verify_batches(&node);
+            state.net.verify_batches(node);
             node.outputs()
         })
         .collect();
@@ -420,15 +420,16 @@ fn do_drop_and_re_add(cfg: TestConfig) {
 }
 
 /// Restarts specified node on the test network for adding it back as a validator.
+#[allow(clippy::needless_collect)]
 fn restart_node_for_add<R, A>(
-    net: &mut VirtualNet<DHB, A>,
-    mut node: Node<DHB>,
+    net: &mut VirtualNet<Dhb, A>,
+    mut node: Node<Dhb>,
     join_plan: JoinPlan<usize>,
     rng: &mut R,
 ) -> Step<DynamicHoneyBadger<Vec<usize>, usize>>
 where
     R: rand::Rng,
-    A: Adversary<DHB>,
+    A: Adversary<Dhb>,
 {
     println!("Restarting node {} with {:?}", node.id(), join_plan);
     // TODO: When an observer node is added to the network, it should also be added to peer_ids.
@@ -449,27 +450,27 @@ where
 /// Internal state of the test.
 struct TestState<A>
 where
-    A: Adversary<DHB>,
+    A: Adversary<Dhb>,
 {
     /// The test network.
-    net: VirtualNet<DHB, A>,
+    net: VirtualNet<Dhb, A>,
     /// The join plan for adding nodes.
     join_plan: Option<JoinPlan<usize>>,
     /// The epoch in which the removed nodes should go offline.
     re_add_epoch: Option<u64>,
     /// The removed nodes which are to be restarted as soon as all remaining
     /// validators agree to add them back.
-    saved_nodes: Vec<Node<DHB>>,
+    saved_nodes: Vec<Node<Dhb>>,
     /// Whether the old subset of validators was applied back to the network.
     old_subset_applied: bool,
 }
 
 impl<A> TestState<A>
 where
-    A: Adversary<DHB>,
+    A: Adversary<Dhb>,
 {
     /// Constructs a new `VirtualNetState`.
-    fn new(net: VirtualNet<DHB, A>) -> Self {
+    fn new(net: VirtualNet<Dhb, A>) -> Self {
         TestState {
             net,
             join_plan: None,

--- a/tests/honey_badger.rs
+++ b/tests/honey_badger.rs
@@ -210,7 +210,7 @@ fn test_honey_badger_different_sizes<A, F>(
     let _ = env_logger::try_init();
 
     let mut rng: TestRng = TestRng::from_seed(seed);
-    let sizes = vec![1, 2, 3, 5, rng.gen_range(6, 10)];
+    let sizes = vec![1, 2, 3, 5, rng.gen_range(6..10)];
     for size in sizes {
         // cloning since it gets moved into a closure
         let cloned_netinfo_map = adversary_netinfo.clone();

--- a/tests/queueing_honey_badger.rs
+++ b/tests/queueing_honey_badger.rs
@@ -251,7 +251,7 @@ fn test_queueing_honey_badger_different_sizes<A, F>(
 
     let mut rng: TestRng = TestRng::from_seed(seed);
 
-    let sizes = vec![2, 3, 5, rng.gen_range(6, 10)];
+    let sizes = vec![2, 3, 5, rng.gen_range(6..10)];
     for size in sizes {
         // The test is removing one correct node, so we allow fewer faulty ones.
         let num_adv_nodes = util::max_faulty(size - 1);

--- a/tests/threshold_sign.rs
+++ b/tests/threshold_sign.rs
@@ -158,19 +158,19 @@ proptest! {
 
     #[test]
     fn test_coin_random_silent_200_samples(seed in gen_seed()) {
-        let new_adversary = || ReorderingAdversary::new();
+        let new_adversary = ReorderingAdversary::new;
         test_coin_different_sizes(new_adversary, 200, seed);
     }
 
     #[test]
     fn test_coin_first_silent_50_samples(seed in gen_seed()) {
-        let new_adversary = || NodeOrderAdversary::new();
+        let new_adversary = NodeOrderAdversary::new;
         test_coin_different_sizes(new_adversary, 50, seed);
     }
 
     #[test]
     fn test_threshold_sign(seed in gen_seed()) {
-        let new_adversary = || ReorderingAdversary::new();
+        let new_adversary = ReorderingAdversary::new;
         test_threshold_sign_different_sizes(new_adversary, seed);
     }
 }

--- a/tests/threshold_sign.rs
+++ b/tests/threshold_sign.rs
@@ -112,7 +112,7 @@ where
     let mut sizes = vec![last_size];
     let num_sizes = (GOOD_SAMPLE_SET.log2() - (num_samples as f64).log2()) as usize;
     for _ in 0..num_sizes {
-        last_size += rng.gen_range(3, 7);
+        last_size += rng.gen_range(3..7);
         sizes.push(last_size);
     }
 


### PR DESCRIPTION
Pretty simple change to update the `threshold_crypto` related libs including `rand`.

I had to remove the mocks because they don't compile in the `threshold_crypto` branch, but it passes `cargo test --release`.

You need to use `--release` when testing or it'll take forever to do the real cryptography.

See also
https://github.com/fedimint/threshold_crypto/pull/3
https://github.com/fedimint/fedimint/pull/499